### PR TITLE
Provide test for the names in `utility_script.jl`

### DIFF
--- a/src/REPLference.jl
+++ b/src/REPLference.jl
@@ -1,0 +1,5 @@
+module REPLference
+
+include("utility_script.jl")
+
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,12 @@
+using InteractiveUtils
+using REPLference
+using Test
+
+@testset "REPLference.jl" begin
+    @test typeof(REPLference._varinfo_to_string(Core)) == String
+    @test typeof(REPLference._varinfo_to_string(Base)) == String
+    @test typeof(REPLference._names_to_dict()) == Dict{Symbol, Vector{String}}
+    @test typeof(REPLference._print_dict_to_dest(REPLference._names_to_dict(), tempname())) == Nothing
+    @test typeof(REPLference._display_vector_as_matrix_in_column_major_order([1, 2, 3, 4])) == Nothing
+    @test typeof(REPLference._print_names()) == Nothing
+end


### PR DESCRIPTION
Adds test for the internal names in `utililty_script.jl`, which automatically creates the `src/REPLference.jl` and `test/runtests.jl` files.